### PR TITLE
Fix shadowrocket rule format.

### DIFF
--- a/app/shadowrocket.py
+++ b/app/shadowrocket.py
@@ -38,6 +38,7 @@ class Shadowrocket(APPBase):
                 f.write("# Last modified: %s\n"%(self.time))
                 f.write("# Blocked domains: %s\n"%(len(blockList)))
                 f.write("#\n")
+                f.write("[Rule]\n")
                 for domain in blockList:
                     f.write("DOMAIN-SUFFIX,%s\n"%(domain))
             


### PR DESCRIPTION
Unable to load shadowrocket rules as a module if there is no "[Rule]" at the beginning.