### PR TITLE
Shadowrocket rules are missing actions. Add REJECT-DROP action.

### DIFF
--- a/app/shadowrocket.py
+++ b/app/shadowrocket.py
@@ -19,10 +19,10 @@ class Shadowrocket(APPBase):
                 logger.info("generate adblock Shadowrocket...")
                 fileName = self.fileName
                 blockList = self.blockList
-            
+
             if os.path.exists(fileName):
                 os.remove(fileName)
-            
+
             # 生成规则文件
             with open(fileName, 'a') as f:
                 f.write("#\n")
@@ -40,8 +40,8 @@ class Shadowrocket(APPBase):
                 f.write("#\n")
                 f.write("[Rule]\n")
                 for domain in blockList:
-                    f.write("DOMAIN-SUFFIX,%s\n"%(domain))
-            
+                    f.write("DOMAIN-SUFFIX,%s,REJECT-DROP\n"%(domain))
+
             if isLite:
                 logger.info("adblock Shadowrocket Lite: block=%d"%(len(blockList)))
             else:


### PR DESCRIPTION
I created a PR hours ago which added "[Rule]" at the beginning. Then I released that the rules are missing actions. So I created this PR.

But I have noticed a comment https://github.com/217heidai/adblockfilters/issues/107#issuecomment-2644475394 which mentioned that users can add these rules by DOMAIN-SET: 
```
DOMAIN-SET,https://raw.githubusercontent.com/217heidai/adblockfilters/main/rules/adblockclash.list,REJECT
DOMAIN-SET,https://raw.githubusercontent.com/217heidai/adblockfilters/main/rules/adblockclash.list,REJECT-DROP
```
I tried this way but never works. I made some searches. Maybe the "[Rule]" line breaks it, or the "DOMAIN-SET" only accepts the domain list like this https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Shadowrocket/Apple/Apple_Domain.list (referring to https://gist.github.com/leohooho/1b8bdbe4314b10154e7287f52cde3254).

If you prefer to keep the DOMAIN-Set way, please comment and close this PR. I will make a new PR to remove "[Rule]".
