### PR TITLE
perf: use DOMAIN-SET instead of DOMAIN/DOMAIN-SUFFIX for faster rule matching in Surge

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,3 +10,4 @@ from .quantumultx import QuantumultX
 from .shadowrocket import Shadowrocket
 from .singbox import SingBox
 from .smartdns import SmartDNS
+from .surge import Surge

--- a/app/surge.py
+++ b/app/surge.py
@@ -1,0 +1,57 @@
+import os
+from typing import List, Set, Dict
+
+from loguru import logger
+
+from app.base import APPBase
+
+class Surge(APPBase):
+    def __init__(self, blockList:List[str], unblockList:List[str], filterDict:Dict[str,str], filterList:List[str], filterList_var:List[str], ChinaSet:Set[str], fileName:str, sourceRule:str):
+        super(Surge, self).__init__(blockList, unblockList, filterDict, filterList, filterList_var, ChinaSet, fileName, sourceRule)
+
+    def generate(self, isLite=False):
+        try:
+            if isLite:
+                logger.info("generate adblock Surge Lite...")
+                fileName = self.fileNameLite
+                blockList = self.blockListLite
+            else:
+                logger.info("generate adblock Surge...")
+                fileName = self.fileName
+                blockList = self.blockList
+
+            if os.path.exists(fileName):
+                os.remove(fileName)
+
+            # 生成规则文件
+            with open(fileName, 'a') as f:
+                f.write("#\n")
+                if isLite:
+                    f.write("#!name=AdBlock Surge Lite\n")
+                    f.write("#!desc=适用于 Surge 的去广告合并规则，每 8 个小时更新一次。规则源：%s。Lite 版仅针对国内域名拦截。\n"%(self.sourceRule))
+                else:
+                    f.write("#!name=AdBlock Surge\n")
+                    f.write("#!desc=适用于 Surge 的去广告合并规则，每 8 个小时更新一次。规则源：%s。\n"%(self.sourceRule))
+                f.write("#!homepage=%s\n"%(self.homepage))
+                f.write("#!raw-url=%s/%s\n"%(self.source, os.path.basename(fileName)))
+                f.write("#!tag=AdBlock, 217heidai\n")
+                f.write("# Example snippet:\n")
+                f.write("# [Rule]\n")
+                f.write("# DOMSIN-SET,%s/%s,REJECT-DROP\n"%(self.source, os.path.basename(fileName)))
+                f.write("#!system=iOS, iPadOS\n")
+                f.write("#!system_version=\n")
+                f.write("#!loon_version=\n")
+                f.write("#!date=%s\n"%(self.time))
+                f.write("#!support=%s\n"%(len(blockList)))
+                f.write("#!proxy-select=REJECT-DROP\n")
+                f.write("#\n")
+                for domain in blockList:
+                    f.write(f".{domain}\n")
+
+            if isLite:
+                logger.info("adblock Surge Lite: block=%d" % (len(blockList)))
+            else:
+                logger.info("adblock Surge: block=%d" % (len(blockList)))
+        except Exception as e:
+            logger.error("%s" % (e))
+

--- a/filter.py
+++ b/filter.py
@@ -6,7 +6,7 @@ from typing import List,Dict,Set,Tuple
 from loguru import logger
 from tld import get_tld
 
-from app import APPBase, AdGuard, AdGuardHome, DNSMasq, Hosts, InviZible, Loon, Mihomo, QuantumultX, Shadowrocket, SingBox, SmartDNS
+from app import APPBase, AdGuard, AdGuardHome, DNSMasq, Hosts, InviZible, Loon, Mihomo, QuantumultX, Shadowrocket, SingBox, SmartDNS, Surge
 from readme import Rule
 from resolver import Resolver
 
@@ -239,6 +239,7 @@ class Filter(object):
             Shadowrocket(blockList, unblockList, filterDict, filterList, filterList_var, ChinaSet, self.path + "/adblockclash.list",    sourceRule),
             SingBox     (blockList, unblockList, filterDict, filterList, filterList_var, ChinaSet, self.path + "/adblocksingbox.json",  sourceRule),
             SmartDNS    (blockList, unblockList, filterDict, filterList, filterList_var, ChinaSet, self.path + "/adblocksmartdns.conf", sourceRule),
+            Surge       (blockList, unblockList, filterDict, filterList, filterList_var, ChinaSet, self.path + "/adblocksurge.list",     sourceRule),
         ]
         for g in generaterList:
             g.generateAll()

--- a/readme.py
+++ b/readme.py
@@ -121,8 +121,10 @@ class ReadMe(object):
             f.write("| 规则11' |" + self.__subscribeLink("adblocksingboxlite.json") + " sing-box 1.12.x json |\n")
             f.write("| 规则12 |" + self.__subscribeLink("adblocksingbox.srs") + " sing-box 1.12.x srs |\n")
             f.write("| 规则12' |" + self.__subscribeLink("adblocksingboxlite.srs") + " sing-box 1.12.x srs |\n")
-            f.write("| 规则13 |" + self.__subscribeLink("adblockloon.list") + " Loon、Surge |\n")
-            f.write("| 规则13' |" + self.__subscribeLink("adblockloonlite.list") + " Loon、Surge |\n")
+            f.write("| 规则13 |" + self.__subscribeLink("adblockloon.list") + " Loon |\n")
+            f.write("| 规则13' |" + self.__subscribeLink("adblockloonlite.list") + " Loon |\n")
+            f.write("| 规则14 |" + self.__subscribeLink("adblocksurge.list") + " Surge |\n")
+            f.write("| 规则14' |" + self.__subscribeLink("adblocksurgelite.list") + " Surge |\n")
             f.write("\n")
 
             f.write("## 上游规则源\n")


### PR DESCRIPTION
## Summary
This PR updates our Surge rule generation logic to use aggregated `DOMAIN-SET` entries instead of per-entry `DOMAIN` or `DOMAIN-SUFFIX` rules.

For large rule lists, `RULE-SET` and `DOMAIN-SET` resources are now automatically preprocessed and indexed during updates, significantly improving matching performance. This change ensures that large rule lists load faster and execute more efficiently [1].

## Example: New Generator Output(Aggregated DOMAIN-SET)
```text
.00-coopb144.com
.00-coopban523.com
.00-lhvpromt.com
.00001.cfd
.000123456789.online
.000123456789.site
.00055edc1917.com
.00080.info
.sanrjeofikacje24.00090.info
.kwflvcdn.000dn.com
.000free.us
.000nethost.com
.000space.com
.000webhost.com
.000webhost.fr
```

## Surge config usage:
```yaml
DOMSIN-SET,https://raw.githubusercontent.com/217heidai/adblockfilters/main/rules/adblocksurge.list,REJECT-DROP
```

[1]: https://kb.nssurge.com/surge-knowledge-base/release-notes/surge-ios#rule-engine-optimizations