### PR TITLE
Empty rule set causes crash in asyncio.wait

### DIFF
--- a/refreshcdn.py
+++ b/refreshcdn.py
@@ -52,6 +52,8 @@ class RefreshCDN(object):
             logger.info("refresh %s..."%(rule))
             task = asyncio.ensure_future(self.__refresh(rule))
             taskList.append(task)
+        if not taskList:
+            return
         # 等待异步任务结束
         loop.run_until_complete(asyncio.wait(taskList))
 


### PR DESCRIPTION
## Summary

refresh() always calls asyncio.wait(taskList) even when no rule files are discovered. asyncio.wait([]) raises ValueError("Set of Tasks/Futures is empty"), so the refresh job crashes instead of exiting cleanly. This can happen when rules directory is empty or filtered out.

## Files changed

- `refreshcdn.py` (modified)

## Testing

- Not run in this environment.
