### PR TITLE
IndexError when generating sing-box output with empty blockList

### DIFF
--- a/app/singbox.py
+++ b/app/singbox.py
@@ -30,9 +30,11 @@ class SingBox(APPBase):
                 f.write('  "rules": [\n')
                 f.write('    {\n')
                 f.write('      "domain_suffix": [\n')
-                for i in range(len(blockList) - 1):
-                    f.write('        "%s",\n'%(blockList[i]))
-                f.write('        "%s"\n'%(blockList[-1]))
+                for i in range(len(blockList)):
+                    if i == len(blockList) - 1:
+                        f.write('        "%s"\n'%(blockList[i]))
+                    else:
+                        f.write('        "%s",\n'%(blockList[i]))
                 f.write('      ]\n')
                 f.write('    }\n')
                 f.write('  ]\n')


### PR DESCRIPTION
## Summary

generate() writes `blockList[-1]` unconditionally. If blockList is empty, this raises IndexError and generation fails. This is a classic off-by-one/empty-list edge case that can break production runs when upstream filtering yields zero domains.

## Files changed

- `app/singbox.py` (modified)

## Testing

- Not run in this environment.
