### PR TITLE
将 QQ 空间上传域名加入强制放行并参与全局去重/反向覆盖

### DIFF
--- a/filter.py
+++ b/filter.py
@@ -73,6 +73,7 @@ class Filter(object):
                 for line in f.readlines():
                     if not line.startswith("#") and len(line.replace("\n", "")) > 4:
                         whiteSet.add(line.replace("\n", ""))
+        whiteSet.add("v6.pic.upqzfile.com")
         logger.info("white list: %d"%(len(whiteSet)))
         return whiteSet
     


### PR DESCRIPTION
## Summary

该问题本质是误拦截导致业务不可用（QQ 空间图片上传失败），应在规则生成入口层做“放行优先”处理。需要在 `filter.py` 中维护的本地放行规则（或放行域名列表）加入 `v6.pic.upqzfile.com`，并确保该域名在最终构建时从 `blockList` 中被移除（即使上游规则继续拦截它）。这样可以同时修复 DNS 类输出和 AdGuard 过滤器输出，避免仅在单一格式中放行。.

## Files changed

- `filter.py` (modified)

## Testing

- Not run in this environment.


Closes #216